### PR TITLE
Fix typo in culture filter label

### DIFF
--- a/src/pages/Kartta.jsx
+++ b/src/pages/Kartta.jsx
@@ -170,7 +170,7 @@ function OmaSijainti({ aktiivinen }) {
 const FILTERS = [
   { value: 'all', label: 'Kaikki' },
   { value: 'shopping', label: 'Kauppakeskukset' },
-  { value: 'vapaa-aika', label: 'Kultturi' },
+  { value: 'vapaa-aika', label: 'Kulttuuri' },
   { value: 'transport', label: 'Liikenne' },
   { value: 'iltamenot', label: 'Iltamenot' },
   { value: 'education', label: 'OAMK' },


### PR DESCRIPTION
## Summary
- fix typo in filter label in Kartta page

## Testing
- `npm run lint` *(fails: 'handleLocateClick' unused, 'mapRef' not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841655fe47483289b4a040575566198